### PR TITLE
Allow rpmalloc to be initialized multiple times

### DIFF
--- a/rpmalloc/rpmalloc.cpp
+++ b/rpmalloc/rpmalloc.cpp
@@ -1238,14 +1238,11 @@ static bool _rpmalloc_initialized = false;
 //! Initialize the allocator and setup global data
 int
 rpmalloc_initialize(void) {
-	if (!_rpmalloc_initialized)
-	{
-		_rpmalloc_initialized = true;
-	}
-	else
-	{
+	if (_rpmalloc_initialized) {
 		return 0;
 	}
+	_rpmalloc_initialized = true;
+
 	RPMALLOC_INITIALIZE_THREAD_LOCAL(_memory_thread_heap);
 	RPMALLOC_INITIALIZE_THREAD_LOCAL(_memory_preferred_heap);
 	_memory_heap_id = 0;

--- a/rpmalloc/rpmalloc.cpp
+++ b/rpmalloc/rpmalloc.cpp
@@ -1239,6 +1239,8 @@ static bool _rpmalloc_initialized = false;
 int
 rpmalloc_initialize(void) {
 	if (_rpmalloc_initialized) {
+		// Initialize this thread
+		rpmalloc_thread_initialize();
 		return 0;
 	}
 	_rpmalloc_initialized = true;

--- a/rpmalloc/rpmalloc.cpp
+++ b/rpmalloc/rpmalloc.cpp
@@ -1233,9 +1233,19 @@ _memory_adjust_size_class(size_t iclass) {
 	}
 }
 
+static bool _rpmalloc_initialized = false;
+
 //! Initialize the allocator and setup global data
 int
 rpmalloc_initialize(void) {
+	if (!_rpmalloc_initialized)
+	{
+		_rpmalloc_initialized = true;
+	}
+	else
+	{
+		return 0;
+	}
 	RPMALLOC_INITIALIZE_THREAD_LOCAL(_memory_thread_heap);
 	RPMALLOC_INITIALIZE_THREAD_LOCAL(_memory_preferred_heap);
 	_memory_heap_id = 0;
@@ -1356,6 +1366,8 @@ rpmalloc_finalize(void) {
 	RPMALLOC_FREE_THREAD_LOCAL(_memory_preferred_heap);
 
 	std::atomic_thread_fence(std::memory_order_release);
+
+	_rpmalloc_initialized = false;
 }
 
 int _is_heap_in_use(void* heap) {


### PR DESCRIPTION
Secondary initialization would nullify _segments_head and leak all the
cached buffers there.